### PR TITLE
docs: synchronize navigation headings with markdown headings

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,40 +2,40 @@ site_name: System Design
 docs_dir: system-design
 
 nav:
-  - Introduction: index.md
-  - Example System Design: margo-overview/introduction-system-design.md
-  - Personas: margo-overview/personas.md
+  - index.md
+  - margo-overview/introduction-system-design.md
+  - margo-overview/personas.md
   - Concepts and Terms:
-       - Technical Lexicon: margo-overview/technical-lexicon.md
-       - Application Observability Overview: margo-overview/application-observability-overview.md
+       - margo-overview/technical-lexicon.md
+       - margo-overview/application-observability-overview.md
   - Application Distribution:
-      - Application Package Definition: app-interoperability/application-package-definition.md
-      - Workload Orchestration to App Registry Interactions: app-interoperability/workload-orch-to-app-reg-interaction.md
-      - Publishing Application Observability Data: app-interoperability/publishing-application-observability-data.md
+      - app-interoperability/application-package-definition.md
+      - app-interoperability/workload-orch-to-app-reg-interaction.md
+      - app-interoperability/publishing-application-observability-data.md
   - Device Interoperability:
-      - Device Requirements: device-interoperability/device-requirements.md
-      - Collecting Application Observability Data: device-interoperability/collecting-application-observability-data.md
+      - device-interoperability/device-requirements.md
+      - device-interoperability/collecting-application-observability-data.md
   - Orchestration:
       - Workload:
-          - Management API: orchestration/workload/workload-management-interface-breakdown.md
-          - Onboarding: orchestration/workload/workload-orchestration-edge-onboarding.md
-          - Device Capabilities: orchestration/workload/device-capability-reporting.md
-          - Workload Deployment: orchestration/workload/workload-deployment.md
-          - Consuming Application Observability Data: orchestration/workload/consuming-application-observability-data.md
+          - orchestration/workload/workload-management-interface-breakdown.md
+          - orchestration/workload/workload-orchestration-edge-onboarding.md
+          - orchestration/workload/device-capability-reporting.md
+          - orchestration/workload/workload-deployment.md
+          - orchestration/workload/consuming-application-observability-data.md
   ##    - Device:
   ##  - Appendix:
   ##    - Management API Definition: margo-overview/personas.md
   - Management API Reference:
-      - Overview: margo-api-reference/margo-api-specification.md
+      - margo-api-reference/margo-api-specification.md
       - Workload API:
           - Desired State API:
-              - Desired State: margo-api-reference/workload-api/desired-state-api/desired-state.md
+              - margo-api-reference/workload-api/desired-state-api/desired-state.md
           - Device API:
-              - Device Capabilities: margo-api-reference/workload-api/device-api/device-capabilities.md
-              - Deployment Status: margo-api-reference/workload-api/device-api/deployment-status.md
+              - margo-api-reference/workload-api/device-api/device-capabilities.md
+              - margo-api-reference/workload-api/device-api/deployment-status.md
           - Onboarding API:
-              - Device Onboarding: margo-api-reference/workload-api/onboarding-api/device-onboarding.md
-              - Certificate Download: margo-api-reference/workload-api/onboarding-api/rootca-download.md
+              - margo-api-reference/workload-api/onboarding-api/device-onboarding.md
+              - margo-api-reference/workload-api/onboarding-api/rootca-download.md
 
 theme:
   name: material

--- a/system-design/app-interoperability/publishing-application-observability-data.md
+++ b/system-design/app-interoperability/publishing-application-observability-data.md
@@ -1,3 +1,5 @@
+# Publishing Application Observability Data
+
 Compliant applications MAY choose to expose application specific observability data by sending their observability data to the Open Telemetry collector on the standalone device or cluster. While this is optional, it is highly recommended in order to support distributed diagnostics.
 
 Application developers choosing to expose application metrics, traces or logs for consumption with OpenTelemetry MUST send the data to the OpenTelemetry collector using OTLP.

--- a/system-design/device-interoperability/collecting-application-observability-data.md
+++ b/system-design/device-interoperability/collecting-application-observability-data.md
@@ -1,3 +1,5 @@
+# Collecting Application Observability Data
+
 The device owner MUST deploy, and configure, an OpenTelemetry collector on their device. The device owner MAY choose the deployment model they wish to follow but MUST use one of the following approaches.
 
 For standalone and clustered devices there MUST be at least one OpenTelemetry collector deployed to collect the observability data required below. The Device owner MAY choose to deploy multiple OpenTelemetry collectors with each collector receiving different parts of the observability data required below as long as all required observability data is collected.

--- a/system-design/device-interoperability/device-requirements.md
+++ b/system-design/device-interoperability/device-requirements.md
@@ -1,4 +1,4 @@
-# Margo Edge Compute Device Details
+# Device Requirements
 
 Within Margo, devices are represented by compute hardware that runs within the customers environment to host Margo Compliant Applications. Margo Devices are defined by the roles they can facilitate within the Margo Architecture. An Edge Compute within Margo is initially referenced as a "Device" which represents the initial lifecycle stage. Once the device is onboarded within the Workload Orchestration Software, it assumes a role based on capabilities. 
 Supported Device roles are shown below:

--- a/system-design/index.md
+++ b/system-design/index.md
@@ -1,3 +1,5 @@
+# Introduction
+
 ![(Margo )](./figures/margo-logo.svg)
 
 The Margo initiative is an open collaboration between like-minded organizations and individuals, sharing a common vision: deliver edge interoperability for industrial automation ecosystems. Margo is hosted by the Linux Foundation.

--- a/system-design/margo-overview/application-observability-overview.md
+++ b/system-design/margo-overview/application-observability-overview.md
@@ -1,3 +1,5 @@
+# Application Observability Overview
+
 Observability involves the collection and analysis of information produced by a system to monitor its internal behavior.
 
 Observability data is captured using the following signals:

--- a/system-design/orchestration/workload/consuming-application-observability-data.md
+++ b/system-design/orchestration/workload/consuming-application-observability-data.md
@@ -1,3 +1,5 @@
+# Consuming Application Observability Data
+
 Workload orchestration or observability platform vendors MAY choose to consume observability data exported from the end user's devices to provide valuable services to the end user.
 
 The end user MAY choose to export observability data from Margo compliant devices to other OpenTelemetry collectors or backends within their environment that is not on the device.

--- a/system-design/orchestration/workload/device-capability-reporting.md
+++ b/system-design/orchestration/workload/device-capability-reporting.md
@@ -1,4 +1,4 @@
-# Device Capability
+# Device Capabilities
 
 The purpose of device capabilities reporting is to ensure the workload orchestration solution has the information needed to pair workloads with compatible edge devices. The [device's capabilities](../../margo-api-reference/workload-api/device-api/device-capabilities.md) are reported to the workload orchestration web service using [Margo management API](../../margo-api-reference/margo-api-specification.md).
 

--- a/system-design/orchestration/workload/workload-deployment.md
+++ b/system-design/orchestration/workload/workload-deployment.md
@@ -1,4 +1,4 @@
-# Desired State Storage and Retrieval
+# Workload Deployment
 
 Margo uses an [OpenGitOps](https://opengitops.dev/) approach for managing the edge device's desired state. The workload orchestration solution vendor maintains Git repositories, under their control, to push updates to the desired state for each device being managed. The device's management client is responsible for monitoring the device's assigned Git repository for any changes to the desired state that MUST be applied.
 > Action: The use of GitOps patterns for pulling desired state is still being discussed/investigated. 

--- a/system-design/orchestration/workload/workload-orchestration-edge-onboarding.md
+++ b/system-design/orchestration/workload/workload-orchestration-edge-onboarding.md
@@ -1,4 +1,4 @@
-# Device Management Client Onboarding
+# Onboarding
 In order for the workload orchestration solution to manage the edge device's workloads, the device's management client must first complete onboarding.
 
 > Action: The details in this page are still under discussion and have not been finalized.


### PR DESCRIPTION
### Description

Ensure consistency between markdown files and mkdocs navigation by:
- Adding a top-level heading to each markdown file
- Using the markdown's top-level heading in the mkdocs navigation

This change resolves the issue of previously out-of-sync headings.

#### Issues Addressed

List and link all the issues addressed by this PR.

#### Change Type

Please select the relevant options:

- [ ] Fix (change that resolves an issue)
- [ ] New enhancement (change that adds specification content)
- [X] Content edits (change that edits existing content)

#### Checklist

- [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [X] My changes adhere to the established patterns, and best practices.
