### PR TITLE
fix: normalize amd64 architecture identifier, remove x86_64 aliases

### DIFF
--- a/src/specification/applications/application-description.linkml.yaml
+++ b/src/specification/applications/application-description.linkml.yaml
@@ -289,7 +289,7 @@ classes:
         range: double
         required: true
       architectures:
-        description: The CPU architectures supported by the application. This can be e.g. amd64, x86_64, arm64, arm.
+        description: The CPU architectures supported by the application. This can be e.g. amd64, arm64, arm.
           See the [CpuArchitectureType](#cpuarchitecturetype) definition for all permissible values.
           Multiple arcitecture types can be specified, as the deployment profile may support multiple CPU architectures.
         rank: 20
@@ -715,8 +715,6 @@ enums:
     permissible_values:
       amd64:
         description: AMD 64-bit architecture.
-      x86_64:
-        description: x86 64-bit architecture.
       arm64:
         description: ARM 64-bit architecture.
       arm:

--- a/src/specification/applications/resources/examples/valid/ApplicationDescription-002.yaml
+++ b/src/specification/applications/resources/examples/valid/ApplicationDescription-002.yaml
@@ -42,7 +42,6 @@ deploymentProfiles:
         cores: 1.5
         architectures: 
           - amd64 
-          - x86_64
       memory: 1024Mi
       storage: 10Gi
       peripherals:

--- a/src/specification/applications/resources/index.md.jinja2
+++ b/src/specification/applications/resources/index.md.jinja2
@@ -112,7 +112,6 @@ These enumerations are used as vocabularies for attribute values of the `Applica
 | Permissible Values | Description |
 | --- | --- |
 | amd64 | AMD 64-bit architecture.|
-| x86_64 | x86 64-bit architecture.|
 | arm64 | ARM 64-bit architecture.|
 | arm | ARM 32-bit architecture. |  
 

--- a/system-design/specification/margo-management-interface/device-capabilities.md
+++ b/system-design/specification/margo-management-interface/device-capabilities.md
@@ -94,7 +94,6 @@ These enumerations are used as vocabularies for attribute values of the `DeviceC
 | Permissible Values | Description |
 | --- | --- |
 | amd64 | AMD 64-bit architecture.|
-| x86_64 | x86 64-bit architecture.|
 | arm64 | ARM 64-bit architecture.|
 | arm | ARM 32-bit architecture. |  
 

--- a/system-design/specification/margo-management-interface/workload-management-api-1.0.0.yaml
+++ b/system-design/specification/margo-management-interface/workload-management-api-1.0.0.yaml
@@ -467,7 +467,7 @@ components:
                       type: number
                     architecture:
                       type: string
-                      enum: [amd64, x86_64, arm64, arm]
+                      enum: [amd64, arm64, arm]
                 memory:
                   type: string
                 storage:


### PR DESCRIPTION
### Description

amd64 and x86_64 are different naming conventions for the same architecture. While x86_64 is commonly used in the Linux Kernel context (CONFIG_X86_64, output to `uname -m`), amd64 is used in the Docker (platform linux/amd64) and Kubernetes (Well-Known Label kubernetes.io/arch, populated from GOARCH) context.

The spec should therefore not list them as alternative architectures, but use the common identifier `amd64`. Keeping both leaves unneeded room for interpretation on the implementation side and mandates App developers maintain two values for compatibility.

#### Issues Addressed

None

#### Change Type

Please select the relevant options:

- [ ] Fix (change that resolves an issue)
- [ ] New enhancement (change that adds specification content)
- [X] Content edits (change that edits existing content)

#### Checklist

- [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [X] My changes adhere to the established patterns, and best practices.
