### PR TITLE
feat!: moves object ids to top level attributes

### DIFF
--- a/src/specification/applications/application-description.linkml.yaml
+++ b/src/specification/applications/application-description.linkml.yaml
@@ -78,16 +78,6 @@ classes:
     description: Metadata about the application.
     rank: 10
     attributes:
-      id:
-        description: >-
-          An identifier for the application. The id is used to help create unique identifiers where required, 
-          such as namespaces. The id must be lower case letters and numbers and MAY contain dashes. 
-          Uppercase letters, underscores and periods MUST NOT be used. The id MUST NOT be more than 200 characters.
-        rank: 10
-        range: string
-        pattern: ^[a-z0-9-]{1,200}$
-        status: deprecated
-        deprecated: This field has been moved to the root-level of Application Description object
       name:
         description: >-
           The application's official name. 

--- a/src/specification/applications/application-description.linkml.yaml
+++ b/src/specification/applications/application-description.linkml.yaml
@@ -31,6 +31,15 @@ classes:
         required: true
         equals_string: "ApplicationDescription" 
         rank: 20
+      id:
+        description: >-
+          An identifier for the application. The id is used to help create unique identifiers where required, 
+          such as namespaces. The id must be lower case letters and numbers and MAY contain dashes. 
+          Uppercase letters, underscores and periods MUST NOT be used. The id MUST NOT be more than 200 characters.
+        rank: 25
+        range: string
+        required: true
+        pattern: ^[a-z0-9-]{1,200}$
       metadata:
         description: >-
           Metadata element specifying characteristics about the application deployment.
@@ -76,8 +85,9 @@ classes:
           Uppercase letters, underscores and periods MUST NOT be used. The id MUST NOT be more than 200 characters.
         rank: 10
         range: string
-        required: true
         pattern: ^[a-z0-9-]{1,200}$
+        status: deprecated
+        deprecated: This field has been moved to the root-level of Application Description object
       name:
         description: >-
           The application's official name. 

--- a/src/specification/applications/resources/examples/invalid/ApplicationDescription-001.yaml
+++ b/src/specification/applications/resources/examples/invalid/ApplicationDescription-001.yaml
@@ -1,0 +1,62 @@
+# Demonstrates validation of kind field
+# Invalid kind of Kubernetes custom resource.
+apiVersion: margo.org/v1-alpha1
+# `kind` != `ApplicationDescription`
+kind: SomethingErroneous
+id: com-northstartida-hello-world
+metadata:
+  name: Hello World
+  description: A basic hello world application
+  version: "1.0"
+  catalog:
+    application:
+      icon: ./resources/hw-logo.png
+      tagline: Northstar Industrial Application's hello world application.
+      descriptionFile: ./resources/description.md
+      releaseNotes: ./resources/release-notes.md
+      licenseFile: ./resources/license.pdf
+      site: http://www.northstar-ida.com
+      tags: ["monitoring"]
+    author:
+      - name: Roger Wilkershank
+        email: rpwilkershank@northstar-ida.com
+    organization:
+      - name: Northstar Industrial Applications
+        site: http://northstar-ida.com
+deploymentProfiles:
+  - type: helm.v3
+    id: com-northstartida-hello-world-helm.v3-a
+    components:
+      - name: hello-world
+        properties:
+          repository: oci://northstarida.azurecr.io/charts/hello-world
+          revision: 1.0.1
+          wait: true
+parameters:
+  greeting:
+    value: Hello
+    targets:
+      - pointer: global.config.appGreeting
+        components: ["hello-world"]
+  greetingAddressee:
+    value: World
+    targets:
+      - pointer: global.config.appGreetingAddressee
+        components: ["hello-world"]
+configuration:
+  sections:
+    - name: General Settings
+      settings:
+        - parameter: greeting
+          name: Greeting
+          description: The greeting to use.
+          schema: requireText
+        - parameter: greetingAddressee
+          name: Greeting Addressee
+          description: The person, or group, the greeting addresses.
+          schema: requireText
+  schema:
+    - name: requireText
+      dataType: string
+      maxLength: 45
+      allowEmpty: false

--- a/src/specification/applications/resources/examples/invalid/ApplicationDescription-002.yaml
+++ b/src/specification/applications/resources/examples/invalid/ApplicationDescription-002.yaml
@@ -1,0 +1,210 @@
+# Demonstrates validation of id field
+# Invalid id format being defined in this test
+apiVersion: margo.org/v1-alpha1
+kind: ApplicationDescription
+id: an-incorrect-id-with-special-chars**&%
+metadata:
+  name: Digitron orchestrator
+  description: The Digitron orchestrator application
+  version: 1.2.1
+  catalog:
+    application:
+      icon: ./resources/ndo-logo.png
+      tagline: Northstar Industrial Application's next-gen, AI driven, Digitron instrument orchestrator.
+      descriptionFile: ./resources/description.md
+      releaseNotes: ./resources/release-notes.md
+      licenseFile: ./resources/license.pdf
+      site: http://www.northstar-ida.com
+      tags: ["optimization", "instrumentation"]
+    author:
+      - name: Roger Wilkershank
+        email: rpwilkershank@northstar-ida.com
+    organization:
+      - name: Northstar Industrial Applications
+        site: http://northstar-ida.com
+deploymentProfiles:
+  - type: helm.v3
+    id: com-northstartida-digitron-orchestrator-helm.v3-a
+    description:
+      This allows to install / run the application as a Helm chart deployment.
+      The device where this application is installed needs to have a screen and a keyboard (as indicated in the required peripherals).
+    components:
+      - name: database-services
+        properties:
+          repository: oci://quay.io/charts/realtime-database-services
+          revision: 2.3.7
+          wait: true
+          timeout: 8m30s
+      - name: digitron-orchestrator
+        properties:
+          repository: oci://northstarida.azurecr.io/charts/northstarida-digitron-orchestrator
+          revision: 1.0.9
+          wait: true
+    requiredResources:
+      cpu:
+        cores: 1.5
+        architectures:
+          - amd64
+      memory: 1024Mi
+      storage: 10Gi
+      peripherals:
+        - type: gpu
+          manufacturer: NVIDIA
+        - type: display
+      interfaces:
+        - type: ethernet
+        - type: bluetooth
+  - type: compose
+    id: com-northstartida-digitron-orchestrator-compose-a
+    components:
+      - name: digitron-orchestrator-docker
+        properties:
+          packageLocation: https://northsitarida.com/digitron/docker/digitron-orchestrator.tar.gz
+          keyLocation: https://northsitarida.com/digitron/docker/public-key.asc
+parameters:
+  idpName:
+    targets:
+      - pointer: idp.name
+        components: ["digitron-orchestrator"]
+      - pointer: ENV.IDP_NAME
+        components: ["digitron-orchestrator-docker"]
+  idpProvider:
+    targets:
+      - pointer: idp.provider
+        components: ["digitron-orchestrator"]
+      - pointer: ENV.IDP_PROVIDER
+        components: ["digitron-orchestrator-docker"]
+  idpClientId:
+    targets:
+      - pointer: idp.clientId
+        components: ["digitron-orchestrator"]
+      - pointer: ENV.IDP_CLIENT_ID
+        components: ["digitron-orchestrator-docker"]
+  idpUrl:
+    targets:
+      - pointer: idp.providerUrl
+        components: ["digitron-orchestrator"]
+      - pointer: idp.providerMetadata
+        components: ["digitron-orchestrator"]
+      - pointer: ENV.IDP_URL
+        components: ["digitron-orchestrator-docker"]
+  adminName:
+    targets:
+      - pointer: administrator.name
+        components: ["digitron-orchestrator"]
+      - pointer: ENV.ADMIN_NAME
+        components: ["digitron-orchestrator-docker"]
+  adminPrincipalName:
+    targets:
+      - pointer: administrator.userPrincipalName
+        components: ["digitron-orchestrator"]
+      - pointer: ENV.ADMIN_PRINCIPALNAME
+        components: ["digitron-orchestrator-docker"]
+  pollFrequency:
+    value: 30
+    targets:
+      - pointer: settings.pollFrequency
+        components: ["digitron-orchestrator", "database-services"]
+      - pointer: ENV.POLL_FREQUENCY
+        components: ["digitron-orchestrator-docker"]
+  siteId:
+    targets:
+      - pointer: settings.siteId
+        components: ["digitron-orchestrator", "database-services"]
+      - pointer: ENV.SITE_ID
+        components: ["digitron-orchestrator-docker"]
+  cpuLimit:
+    value: 1
+    targets:
+      - pointer: settings.limits.cpu
+        components: ["digitron-orchestrator"]
+  memoryLimit:
+    value: 16384
+    targets:
+      - pointer: settings.limits.memory
+        components: ["digitron-orchestrator"]
+configuration:
+  sections:
+    - name: General
+      settings:
+        - parameter: pollFrequency
+          name: Poll Frequency
+          description: How often the service polls for updated data in seconds
+          schema: pollRange
+        - parameter: siteId
+          name: Site Id
+          description: Special identifier for the site (optional)
+          schema: optionalText
+    - name: Identity Provider
+      settings:
+        - parameter: idpName
+          name: Name
+          description: The name of the Identity Provider to use
+          immutable: true
+          schema: requiredText
+        - parameter: idpProvider
+          name: Provider
+          description: Provider something something
+          immutable: true
+          schema: requiredText
+        - parameter: idpClientId
+          name: Client ID
+          description: The client id
+          immutable: true
+          schema: requiredText
+        - parameter: idpUrl
+          name: Provider URL
+          description: The url of the Identity Provider
+          immutable: true
+          schema: url
+    - name: Administrator
+      settings:
+        - parameter: adminName
+          name: Presentation Name
+          description: The presentation name of the administrator
+          schema: requiredText
+        - parameter: adminPrincipalName
+          name: Principal Name
+          description: The principal name of the administrator
+          schema: email
+    - name: Resource Limits
+      settings:
+        - parameter: cpuLimit
+          name: CPU Limit
+          description: Maximum number of CPU cores to allow the application to consume
+          schema: cpuRange
+        - parameter: memoryLimit
+          name: Memory Limit
+          description: Maximum number of memory to allow the application to consume
+          schema: memoryRange
+  schema:
+    - name: requiredText
+      dataType: string
+      maxLength: 45
+      allowEmpty: false
+    - name: email
+      dataType: string
+      allowEmpty: false
+      regexMatch: .*@[a-z0-9.-]*
+    - name: url
+      dataType: string
+      allowEmpty: false
+      regexMatch: ^(http(s):\/\/.)[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)$
+    - name: pollRange
+      dataType: integer
+      minValue: 30
+      maxValue: 360
+      allowEmpty: false
+    - name: optionalText
+      dataType: string
+      minLength: 5
+      allowEmpty: true
+    - name: cpuRange
+      dataType: double
+      minValue: 0.5
+      maxPrecision: 1
+      allowEmpty: false
+    - name: memoryRange
+      dataType: integer
+      minValue: 16384
+      allowEmpty: false

--- a/src/specification/applications/resources/examples/valid/ApplicationDescription-001.yaml
+++ b/src/specification/applications/resources/examples/valid/ApplicationDescription-001.yaml
@@ -1,7 +1,7 @@
 apiVersion: margo.org/v1-alpha1
 kind: ApplicationDescription
+id: com-northstartida-hello-world
 metadata:
-  id: com-northstartida-hello-world
   name: Hello World
   description: A basic hello world application
   version: "1.0"

--- a/src/specification/applications/resources/examples/valid/ApplicationDescription-002.yaml
+++ b/src/specification/applications/resources/examples/valid/ApplicationDescription-002.yaml
@@ -1,7 +1,7 @@
 apiVersion: margo.org/v1-alpha1
 kind: ApplicationDescription
+id: com-northstartida-digitron-orchestrator
 metadata:
-  id: com-northstartida-digitron-orchestrator
   name: Digitron orchestrator
   description: The Digitron orchestrator application
   version: 1.2.1 

--- a/src/specification/applications/resources/index.md.jinja2
+++ b/src/specification/applications/resources/index.md.jinja2
@@ -34,7 +34,8 @@ which defines the [desired state](../margo-management-interface/desired-state.md
 | Attribute | Type | Required? | Description |
 | --- | --- | --- | --- |
 {% for slot in schemaview.class_slots("ApplicationDescription")|sort(attribute='rank') -%}
-| {{ slot }} | {{ format_range(schemaview.get_slot(slot)) }} | {% if schemaview.get_slot(slot).required == True %} Y {% else %} N {% endif %} | {{ schemaview.get_slot(slot).description }}|
+{% set slot_def = schemaview.induced_slot(slot, "ApplicationDescription") -%}
+| {{ slot }} | {{ format_range(slot_def) }} | {% if slot_def.required == True %} Y {% else %} N {% endif %} | {{ slot_def.description }}|
 {% endfor -%}
 
 {% for c in gen.all_class_objects()|sort(attribute='rank') %}

--- a/src/specification/margo-management-interface/desired-state.linkml.yaml
+++ b/src/specification/margo-management-interface/desired-state.linkml.yaml
@@ -75,12 +75,8 @@ classes:
     attributes:
       applicationId:
         description: >-
-          An identifier for the application.
-          The id is used to help create unique identifiers where required, such as namespaces.
-          The id must be lower case letters and numbers and MAY contain dashes.
-          Uppercase letters, underscores and periods MUST NOT be used.
-          The id MUST NOT be more than 200 characters.
-          The applicationId MUST match the associated application package Metadata "id" attribute.
+          It MUST match the associated application description Metadata "id" attribute.
+          It can be used to help create unique identifiers where required, such as namespaces.
         required: true
         range: string
         pattern: "^[-a-z0-9]{1,200}$"

--- a/src/specification/margo-management-interface/desired-state.linkml.yaml
+++ b/src/specification/margo-management-interface/desired-state.linkml.yaml
@@ -56,30 +56,22 @@ classes:
     description: Metadata associated with the desired state.
     rank: 10
     attributes:
-      annotations:
-        description: >-
-          Defines the meta information associated to the deployment specification.
-          Needs to be assigned by the Workload Fleet Manager.
-          See the [Annotation Attributes](#annotations-attributes) section below.
-        range: Annotations
-        required: true
-        rank: 10
       name:
         description: >-
           When deploying to Kubernetes, the manifests name.
           The name is chosen by the Workload Fleet Management vendor and is not displayed anywhere.
         required: true
         range: string
-        rank: 20
+        rank: 10
       namespace:
         description: When deploying to Kubernetes, the namespace the manifest is added under. The namespace is chosen by the Workload Fleet Management vendor.
         required: true
         range: string
-        rank: 30
+        rank: 20
 
-  Annotations:
-    description: A class representing annotations.
-    rank: 20
+  Spec:
+    description: Specification details of the desired state.
+    rank: 30
     attributes:
       applicationId:
         description: >-
@@ -93,11 +85,6 @@ classes:
         range: string
         pattern: "^[-a-z0-9]{1,200}$"
         rank: 10
-
-  Spec:
-    description: Specification details of the desired state.
-    rank: 30
-    attributes:
       deploymentProfile:
         description: Section that defines deployment details including type and components.
         range: DeploymentProfile

--- a/src/specification/margo-management-interface/desired-state.linkml.yaml
+++ b/src/specification/margo-management-interface/desired-state.linkml.yaml
@@ -29,6 +29,13 @@ classes:
         required: true
         range: string
         rank: 20
+      id:
+        description: >-
+          The unique identifier UUID of the deployment specification.
+          Needs to be assigned by the Workload Orchestration Software.
+        required: true
+        pattern: "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+        rank: 25
       metadata:
         description: >-
           Metadata element specifying characteristics about the application deployment.
@@ -86,9 +93,11 @@ classes:
         description: >-
           The unique identifier UUID of the deployment specification.
           Needs to be assigned by the Workload Orchestration Software.
-        required: true
         pattern: "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
         rank: 20
+        status: deprecated
+        deprecated: "This field has been moved to root level in DesiredState object"
+        deprecated_element_has_possible_replacement: DesiredState:id
 
   Spec:
     description: Specification details of the desired state.

--- a/src/specification/margo-management-interface/desired-state.linkml.yaml
+++ b/src/specification/margo-management-interface/desired-state.linkml.yaml
@@ -57,7 +57,7 @@ classes:
     attributes:
       annotations:
         description: >-
-          Defines the application ID and unique identifier associated to the deployment specification.
+          Defines the meta information associated to the deployment specification.
           Needs to be assigned by the Workload Orchestration Software.
           See the [Annotation Attributes](#annotations-attributes) section below.
         range: Annotations
@@ -97,7 +97,6 @@ classes:
         rank: 20
         status: deprecated
         deprecated: "This field has been moved to root level in DesiredState object"
-        deprecated_element_has_possible_replacement: DesiredState:id
 
   Spec:
     description: Specification details of the desired state.

--- a/src/specification/margo-management-interface/desired-state.linkml.yaml
+++ b/src/specification/margo-management-interface/desired-state.linkml.yaml
@@ -80,7 +80,7 @@ classes:
         required: true
         range: string
         pattern: "^[-a-z0-9]{1,200}$"
-        rank: 10
+        rank: 5
       deploymentProfile:
         description: Section that defines deployment details including type and components.
         range: DeploymentProfile

--- a/src/specification/margo-management-interface/desired-state.linkml.yaml
+++ b/src/specification/margo-management-interface/desired-state.linkml.yaml
@@ -75,7 +75,7 @@ classes:
     attributes:
       applicationId:
         description: >-
-          It MUST match the associated application description Metadata "id" attribute.
+          It MUST match the associated application description's top-level "id" attribute.
           It can be used to help create unique identifiers where required, such as namespaces.
         required: true
         range: string

--- a/src/specification/margo-management-interface/desired-state.linkml.yaml
+++ b/src/specification/margo-management-interface/desired-state.linkml.yaml
@@ -32,7 +32,7 @@ classes:
       id:
         description: >-
           The unique identifier UUID of the deployment specification.
-          Needs to be assigned by the Workload Orchestration Software.
+          Needs to be assigned by the Workload Fleet Manager.
         required: true
         range: string
         pattern: "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
@@ -59,7 +59,7 @@ classes:
       annotations:
         description: >-
           Defines the meta information associated to the deployment specification.
-          Needs to be assigned by the Workload Orchestration Software.
+          Needs to be assigned by the Workload Fleet Manager.
           See the [Annotation Attributes](#annotations-attributes) section below.
         range: Annotations
         required: true
@@ -67,12 +67,12 @@ classes:
       name:
         description: >-
           When deploying to Kubernetes, the manifests name.
-          The name is chosen by the workload orchestration vendor and is not displayed anywhere.
+          The name is chosen by the Workload Fleet Management vendor and is not displayed anywhere.
         required: true
         range: string
         rank: 20
       namespace:
-        description: When deploying to Kubernetes, the namespace the manifest is added under. The namespace is chosen by the workload orchestration solution vendor.
+        description: When deploying to Kubernetes, the namespace the manifest is added under. The namespace is chosen by the Workload Fleet Management vendor.
         required: true
         range: string
         rank: 30

--- a/src/specification/margo-management-interface/desired-state.linkml.yaml
+++ b/src/specification/margo-management-interface/desired-state.linkml.yaml
@@ -34,6 +34,7 @@ classes:
           The unique identifier UUID of the deployment specification.
           Needs to be assigned by the Workload Orchestration Software.
         required: true
+        range: string
         pattern: "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
         rank: 25
       metadata:
@@ -68,10 +69,12 @@ classes:
           When deploying to Kubernetes, the manifests name.
           The name is chosen by the workload orchestration vendor and is not displayed anywhere.
         required: true
+        range: string
         rank: 20
       namespace:
         description: When deploying to Kubernetes, the namespace the manifest is added under. The namespace is chosen by the workload orchestration solution vendor.
         required: true
+        range: string
         rank: 30
 
   Annotations:
@@ -87,16 +90,9 @@ classes:
           The id MUST NOT be more than 200 characters.
           The applicationId MUST match the associated application package Metadata "id" attribute.
         required: true
+        range: string
         pattern: "^[-a-z0-9]{1,200}$"
         rank: 10
-      id:
-        description: >-
-          The unique identifier UUID of the deployment specification.
-          Needs to be assigned by the Workload Orchestration Software.
-        pattern: "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
-        rank: 20
-        status: deprecated
-        deprecated: "This field has been moved to root level in DesiredState object"
 
   Spec:
     description: Specification details of the desired state.

--- a/src/specification/margo-management-interface/resources/examples/invalid/DesiredState-001.yaml
+++ b/src/specification/margo-management-interface/resources/examples/invalid/DesiredState-001.yaml
@@ -1,4 +1,4 @@
-# Demonstrates validation of metadata.annotations.id
+# Demonstrates validation of kind field
 # Invalid kind of Kubernetes custom resource.
 apiVersion: application.margo.org/v1alpha1
 # `kind` != `ApplicationDeployment`

--- a/src/specification/margo-management-interface/resources/examples/invalid/DesiredState-001.yaml
+++ b/src/specification/margo-management-interface/resources/examples/invalid/DesiredState-001.yaml
@@ -5,11 +5,10 @@ apiVersion: application.margo.org/v1alpha1
 kind: SomethingErroneous
 id: a3e2f5dc-912e-494f-8395-52cf3769bc06
 metadata:
-    annotations:
-        applicationId: com-northstartida-digitron-orchestrator
     name: com-northstartida-digitron-orchestrator-deployment
     namespace: margo-poc
 spec:
+    applicationId: com-northstartida-digitron-orchestrator
     deploymentProfile:
         type: helm
         components:

--- a/src/specification/margo-management-interface/resources/examples/invalid/DesiredState-001.yaml
+++ b/src/specification/margo-management-interface/resources/examples/invalid/DesiredState-001.yaml
@@ -3,10 +3,10 @@
 apiVersion: application.margo.org/v1alpha1
 # `kind` != `ApplicationDeployment`
 kind: SomethingErroneous
+id: a3e2f5dc-912e-494f-8395-52cf3769bc06
 metadata:
     annotations:
         applicationId: com-northstartida-digitron-orchestrator
-        id: a3e2f5dc-912e-494f-8395-52cf3769bc06
     name: com-northstartida-digitron-orchestrator-deployment
     namespace: margo-poc
 spec:

--- a/src/specification/margo-management-interface/resources/examples/invalid/DesiredState-002.yaml
+++ b/src/specification/margo-management-interface/resources/examples/invalid/DesiredState-002.yaml
@@ -1,15 +1,14 @@
-# Demonstrates validation of metadata.annotations.applicationId
+# Demonstrates validation of spec.applicationId
 # Invalid characters being used.
 apiVersion: application.margo.org/v1alpha1
 kind: ApplicationDeployment
 id: a3e2f5dc-912e-494f-8395-52cf3769bc06
 metadata:
-    annotations:
-        # id contains invalid characters: upper-case letters ('A' and 'Z'), special characters ('.' and '_')
-        applicationId: com_northstartida.Digitron-Orchestrator
     name: com-northstartida-digitron-orchestrator-deployment
     namespace: margo-poc
 spec:
+    # id contains invalid characters: upper-case letters ('A' and 'Z'), special characters ('.' and '_')
+    applicationId: com_northstartida.Digitron-Orchestrator
     deploymentProfile:
         type: helm
         components:

--- a/src/specification/margo-management-interface/resources/examples/invalid/DesiredState-002.yaml
+++ b/src/specification/margo-management-interface/resources/examples/invalid/DesiredState-002.yaml
@@ -2,11 +2,11 @@
 # Invalid characters being used.
 apiVersion: application.margo.org/v1alpha1
 kind: ApplicationDeployment
+id: a3e2f5dc-912e-494f-8395-52cf3769bc06
 metadata:
     annotations:
         # id contains invalid characters: upper-case letters ('A' and 'Z'), special characters ('.' and '_')
         applicationId: com_northstartida.Digitron-Orchestrator
-        id: a3e2f5dc-912e-494f-8395-52cf3769bc06
     name: com-northstartida-digitron-orchestrator-deployment
     namespace: margo-poc
 spec:

--- a/src/specification/margo-management-interface/resources/examples/invalid/DesiredState-003.yaml
+++ b/src/specification/margo-management-interface/resources/examples/invalid/DesiredState-003.yaml
@@ -2,11 +2,11 @@
 # Too long.
 apiVersion: application.margo.org/v1alpha1
 kind: ApplicationDeployment
+id: a3e2f5dc-912e-494f-8395-52cf3769bc06
 metadata:
     annotations:
         # id is over 200 characters long (it is 201 characters long)
         applicationId: "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901"
-        id: a3e2f5dc-912e-494f-8395-52cf3769bc06
     name: com-northstartida-digitron-orchestrator-deployment
     namespace: margo-poc
 spec:

--- a/src/specification/margo-management-interface/resources/examples/invalid/DesiredState-003.yaml
+++ b/src/specification/margo-management-interface/resources/examples/invalid/DesiredState-003.yaml
@@ -1,15 +1,14 @@
-# Demonstrates validation of metadata.annotations.applicationId
+# Demonstrates validation of spec.applicationId
 # Too long.
 apiVersion: application.margo.org/v1alpha1
 kind: ApplicationDeployment
 id: a3e2f5dc-912e-494f-8395-52cf3769bc06
 metadata:
-    annotations:
-        # id is over 200 characters long (it is 201 characters long)
-        applicationId: "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901"
     name: com-northstartida-digitron-orchestrator-deployment
     namespace: margo-poc
 spec:
+    # id is over 200 characters long (it is 201 characters long)
+    applicationId: "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901"
     deploymentProfile:
         type: helm
         components:

--- a/src/specification/margo-management-interface/resources/examples/invalid/DesiredState-004.yaml
+++ b/src/specification/margo-management-interface/resources/examples/invalid/DesiredState-004.yaml
@@ -5,11 +5,10 @@ kind: ApplicationDeployment
 # id is not a valid UUID
 id: this-is-definitively-not-a-uuid
 metadata:
-    annotations:
-        applicationId: com-northstartida-digitron-orchestrator
     name: com-northstartida-digitron-orchestrator-deployment
     namespace: margo-poc
 spec:
+    applicationId: com-northstartida-digitron-orchestrator
     deploymentProfile:
         type: helm
         components:

--- a/src/specification/margo-management-interface/resources/examples/invalid/DesiredState-004.yaml
+++ b/src/specification/margo-management-interface/resources/examples/invalid/DesiredState-004.yaml
@@ -2,11 +2,11 @@
 # Not a valid UUID.
 apiVersion: application.margo.org/v1alpha1
 kind: ApplicationDeployment
+# id is not a valid UUID
+id: this-is-definitively-not-a-uuid
 metadata:
     annotations:
         applicationId: com-northstartida-digitron-orchestrator
-        # id is not a valid UUID
-        id: this-is-definitively-not-a-uuid
     name: com-northstartida-digitron-orchestrator-deployment
     namespace: margo-poc
 spec:

--- a/src/specification/margo-management-interface/resources/examples/invalid/DesiredState-004.yaml
+++ b/src/specification/margo-management-interface/resources/examples/invalid/DesiredState-004.yaml
@@ -1,4 +1,4 @@
-# Demonstrates validation of metadata.annotations.id
+# Demonstrates validation of id field
 # Not a valid UUID.
 apiVersion: application.margo.org/v1alpha1
 kind: ApplicationDeployment

--- a/src/specification/margo-management-interface/resources/examples/valid/DesiredState-001.yaml
+++ b/src/specification/margo-management-interface/resources/examples/valid/DesiredState-001.yaml
@@ -1,9 +1,9 @@
 apiVersion: application.margo.org/v1alpha1
 kind: ApplicationDeployment
+id: a3e2f5dc-912e-494f-8395-52cf3769bc06
 metadata:
     annotations:
         applicationId: com-northstartida-digitron-orchestrator
-        id: a3e2f5dc-912e-494f-8395-52cf3769bc06
     name: com-northstartida-digitron-orchestrator-deployment
     namespace: margo-poc
 spec:

--- a/src/specification/margo-management-interface/resources/examples/valid/DesiredState-001.yaml
+++ b/src/specification/margo-management-interface/resources/examples/valid/DesiredState-001.yaml
@@ -2,11 +2,10 @@ apiVersion: application.margo.org/v1alpha1
 kind: ApplicationDeployment
 id: a3e2f5dc-912e-494f-8395-52cf3769bc06
 metadata:
-    annotations:
-        applicationId: com-northstartida-digitron-orchestrator
     name: com-northstartida-digitron-orchestrator-deployment
     namespace: margo-poc
 spec:
+    applicationId: com-northstartida-digitron-orchestrator
     deploymentProfile:
         type: helm
         components:

--- a/src/specification/margo-management-interface/resources/examples/valid/DesiredState-002.yaml
+++ b/src/specification/margo-management-interface/resources/examples/valid/DesiredState-002.yaml
@@ -2,11 +2,10 @@ apiVersion: application.margo.org/v1alpha1
 kind: ApplicationDeployment
 id: ad9b614e-8912-45f4-a523-372358765def
 metadata:
-    annotations:
-        applicationId: com-northstartida-digitron-orchestrator
     name: com-northstartida-digitron-orchestrator-deployment
     namespace: margo-poc
 spec:
+    applicationId: com-northstartida-digitron-orchestrator
     deploymentProfile:
         type: compose
         components:

--- a/src/specification/margo-management-interface/resources/examples/valid/DesiredState-002.yaml
+++ b/src/specification/margo-management-interface/resources/examples/valid/DesiredState-002.yaml
@@ -1,9 +1,9 @@
 apiVersion: application.margo.org/v1alpha1
 kind: ApplicationDeployment
+id: ad9b614e-8912-45f4-a523-372358765def
 metadata:
     annotations:
         applicationId: com-northstartida-digitron-orchestrator
-        id: ad9b614e-8912-45f4-a523-372358765def
     name: com-northstartida-digitron-orchestrator-deployment
     namespace: margo-poc
 spec:

--- a/src/specification/margo-management-interface/resources/index.md.jinja2
+++ b/src/specification/margo-management-interface/resources/index.md.jinja2
@@ -272,12 +272,11 @@ This section defines the structure and YAML schema of an `ApplicationDeployment`
 apiVersion: application.margo.org/v1alpha1
 kind: ApplicationDeployment
 id: 
-metadata:
-  annotations:
-    applicationId: 
+metadata: 
   name: 
   namespace: 
 spec:
+    applicationId:
     deploymentProfile:
         type: 
         components:

--- a/src/specification/margo-management-interface/resources/index.md.jinja2
+++ b/src/specification/margo-management-interface/resources/index.md.jinja2
@@ -271,9 +271,9 @@ This section defines the structure and YAML schema of an `ApplicationDeployment`
 ```yaml
 apiVersion: application.margo.org/v1alpha1
 kind: ApplicationDeployment
+id: 
 metadata:
   annotations:
-    id: 
     applicationId: 
   name: 
   namespace: 

--- a/src/specification/margo-management-interface/resources/index.md.jinja2
+++ b/src/specification/margo-management-interface/resources/index.md.jinja2
@@ -85,7 +85,7 @@ GET /api/v1/clients/{clientId}/deployments
 | `bundle.sizeBytes` | number | N | Optional unsigned 64-bit advisory estimate of the decoded payload length in bytes for the bundle archive. Provided for bandwidth estimation and update planning. MUST NOT be used for integrity verification. |
 | `bundle.url` | string | Y | Content-addressable retrieval endpoint for the bundle of the form `/api/v1/clients/{clientId}/bundles/{digest}` where `{digest}` equals `bundle.digest`. |
 | `deployments` | array | Y | List of deployment objects describing each workload. |
-| `deployments[].deploymentId` | string | Y | The UUID of the deployment. MUST equal [`metadata.annotations.id`](#annotations-attributes) in the `ApplicationDeployment`. |
+| `deployments[].deploymentId` | string | Y | The UUID of the deployment. MUST equal top-level `id` attribute in the `ApplicationDeployment`. |
 | `deployments[].digest` | string | Y | Digest of the corresponding `ApplicationDeployment` YAML file. MUST equal the digest computed over the exact sequence of bytes in the [individual deployment endpoint's](#endpoints-individual-deployment-yaml) HTTP `200 OK` response body. See [Protocol - Digest](#protocol-digest) for further details. |
 | `deployments[].sizeBytes` | number | N | Optional unsigned 64-bit advisory estimate of the decoded payload length in bytes for the `ApplicationDeployment` YAML. Provided for bandwidth estimation and update planning. MUST NOT be used for integrity verification. |
 | `deployments[].url` | string | Y | Content-addressable retrieval endpoint for the `ApplicationDeployment` YAML of the form `/api/v1/clients/{clientId}/deployments/{deploymentId}/{digest}` where `{digest}` equals `deployments[].digest`. |
@@ -113,7 +113,7 @@ GET /api/v1/clients/{clientId}/deployments/{deploymentId}/{digest}
 | Parameter | Type | Required? | Description |
 | --------- | ---- | --------- | ----------- |
 | `{clientId}` | string | Y | The unique identifier of the (device) client registered with the WFM during onboarding. |
-| `{deploymentId}` | string | Y | The UUID of the served `ApplicationDeployment` YAML. This MUST equal to `metadata.annotations.id`. |
+| `{deploymentId}` | string | Y | The UUID of the served `ApplicationDeployment` YAML. This MUST equal to top-level `id` attribute in the ApplicationDeployment. |
 | `{digest}` | string | Y | Content-addressable digest of the served `ApplicationDeployment` YAML. See [Protocol - Digest](#protocol-digest) for further details. |
 
 ### Response Codes

--- a/system-design/specification/margo-devices/device-requirements.md
+++ b/system-design/specification/margo-devices/device-requirements.md
@@ -19,7 +19,7 @@ Devices filling the standalone cluster role MUST provide the following additiona
 
 Applications can be deployed as Helm charts using either Helm [version 3](https://helm.sh/docs/v3/topics/charts) or [version 4](https://helm.sh/docs/topics/charts) using Chart APIVersion v2 only.
 
-Margo does not dictate how devices deploy workloads packaged as Helm charts. A device vendor may choose a deployment approach that either interacts with the Kubernetes API (such as `helm install`) or an approach that renders the helm templates and applies the templates (such as `helm template` or Kustomization). In order to facility this choice, certain Helm functions are not support. See the [Helm exceptions](../applications/application-description#helm-exceptions) for more details.
+Margo does not dictate how devices deploy workloads packaged as Helm charts. A device vendor may choose a deployment approach that either interacts with the Kubernetes API (such as `helm install`) or an approach that renders the helm templates and applies the templates (such as `helm template` or Kustomization). In order to facility this choice, certain Helm functions are not support. See the [Helm exceptions](../applications/application-description.md#helm-exceptions) for more details.
 
 #### Probationary support for `.Capabilities.APIVersions.Has` function
 

--- a/system-design/specification/margo-management-interface/workload-management-api-1.0.0.yaml
+++ b/system-design/specification/margo-management-interface/workload-management-api-1.0.0.yaml
@@ -584,10 +584,6 @@ components:
           type: object
           additionalProperties: { type: string }
           description: Labels for the resource
-        annotations:
-          type: object
-          additionalProperties: { type: string }
-          description: Annotations for the resource
     helmApplicationDeploymentProfileComponent:
       type: object
       description: Helm Application Deployment Profile Component
@@ -688,8 +684,18 @@ components:
     appDeploymentSpec:
       type: object
       description: Application Deployment specification
-      required: [appPackageRef, deploymentProfile]
+      required: [applicationId, deploymentProfile]
       properties:
+        applicationId:
+          type: string
+          description: >-
+            An identifier for the application.
+            The id is used to help create unique identifiers where required, such as namespaces.
+            The id must be lower case letters and numbers and MAY contain dashes.
+            Uppercase letters, underscores and periods MUST NOT be used.
+            The id MUST NOT be more than 200 characters.
+            The applicationId MUST match the associated application package Metadata "id" attribute.
+          pattern: "^[-a-z0-9]{1,200}$"
         deploymentProfile:
           $ref: '#/components/schemas/appDeploymentProfile'
           description: Deployment profile

--- a/system-design/specification/margo-management-interface/workload-management-api-1.0.0.yaml
+++ b/system-design/specification/margo-management-interface/workload-management-api-1.0.0.yaml
@@ -262,7 +262,7 @@ paths:
           required: true
           schema:
             type: string
-          description: UUID of the ApplicationDeployment (metadata.annotations.id)
+          description: UUID of the ApplicationDeployment
         - name: digest
           in: path
           required: true
@@ -397,7 +397,7 @@ components:
         deploymentId:
           type: string
           description: >
-            The unique UUID from the ApplicationDeployment's metadata.annotations.id.
+            The unique UUID from the ApplicationDeployment.
         digest:
           type: string
           description: >

--- a/system-design/specification/margo-management-interface/workload-management-api-1.0.0.yaml
+++ b/system-design/specification/margo-management-interface/workload-management-api-1.0.0.yaml
@@ -694,7 +694,7 @@ components:
             The id must be lower case letters and numbers and MAY contain dashes.
             Uppercase letters, underscores and periods MUST NOT be used.
             The id MUST NOT be more than 200 characters.
-            The applicationId MUST match the associated application package Metadata "id" attribute.
+            The applicationId MUST match the associated application description's top-level "id" attribute.
           pattern: "^[-a-z0-9]{1,200}$"
         deploymentProfile:
           $ref: '#/components/schemas/appDeploymentProfile'

--- a/system-design/specification/margo-management-interface/workload-management-api-1.0.0.yaml
+++ b/system-design/specification/margo-management-interface/workload-management-api-1.0.0.yaml
@@ -397,7 +397,7 @@ components:
         deploymentId:
           type: string
           description: >
-            The unique UUID from the ApplicationDeployment.
+            Unique identifier for the application deployment.
         digest:
           type: string
           description: >

--- a/system-design/specification/margo-management-interface/workload-management-api-1.0.0.yaml
+++ b/system-design/specification/margo-management-interface/workload-management-api-1.0.0.yaml
@@ -262,7 +262,7 @@ paths:
           required: true
           schema:
             type: string
-          description: UUID of the ApplicationDeployment
+          description: Unique identifier for the application deployment
         - name: digest
           in: path
           required: true

--- a/system-design/specification/margo-management-interface/workload-management-api-1.0.0.yaml
+++ b/system-design/specification/margo-management-interface/workload-management-api-1.0.0.yaml
@@ -574,12 +574,6 @@ components:
       type: object
       required: [name]
       properties:
-        id:
-          type: string
-          description: |
-            This object has been moved to root level of appDeploymentManifest
-            object.
-          deprecated: true
         name:
           type: string
           description: Name of the resource

--- a/system-design/specification/margo-management-interface/workload-management-api-1.0.0.yaml
+++ b/system-design/specification/margo-management-interface/workload-management-api-1.0.0.yaml
@@ -563,6 +563,9 @@ components:
           type: string
           default: ApplicationDeployment
           description: Resource kind
+        id:
+          type: string
+          description: Unique identifier for the application deployment
         metadata:
           $ref: '#/components/schemas/appDeploymentMetadata'
         spec:
@@ -573,7 +576,10 @@ components:
       properties:
         id:
           type: string
-          description: Unique identifier for the application deployment
+          description: |
+            This object has been moved to root level of appDeploymentManifest
+            object.
+          deprecated: true
         name:
           type: string
           description: Name of the resource


### PR DESCRIPTION
### Description

The application description and deployment ids were nested under `metadata` and `annotations` fields, which in themselves are sub-fields in the respective definitions of app and deployment. This change moves them to the root-level objects i.e. they are accessible directly as `AppDescription.Id` and `AppDeployment.Id` .

#### Issues Addressed

#161 

#### Change Type

Please select the relevant options:

- [ ] Fix (change that resolves an issue)
- [] New enhancement (change that adds specification content)
- [x] Content edits (change that edits existing content)

#### Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [x] My changes adhere to the established patterns, and best practices.
