### PR TITLE
docs(md): fixes onboarding seq diagram

### DIFF
--- a/system-design/specification/margo-management-interface/device-client-onboarding.md
+++ b/system-design/specification/margo-management-interface/device-client-onboarding.md
@@ -34,7 +34,7 @@ sequenceDiagram
     Note over Client,Server: 🔒 Standard TLS Handshake completed
     WFMUser->>Server: Opportunity for user to manually upload client certificate
     Note over Client,Server: Device Client onboarding begins
-    Client->>Server: POST /onboarding with public certificate of the device (could exchange additional info)
+    Client->>Server: POST /onboarding using the device's public certificate (could exchange additional info)
     WFMUser->>Server: Opportunity for user to approve or reject client onboarding
     alt Public key trusted/user approved
         Note over Server: Server verifies client certificate and assigns UUID

--- a/system-design/specification/margo-management-interface/device-client-onboarding.md
+++ b/system-design/specification/margo-management-interface/device-client-onboarding.md
@@ -34,7 +34,7 @@ sequenceDiagram
     Note over Client,Server: 🔒 Standard TLS Handshake completed
     WFMUser->>Server: Opportunity for user to manually upload client certificate
     Note over Client,Server: Device Client onboarding begins
-    Client->>Server: POST /onboarding with public_certificate (could exchange additional info)
+    Client->>Server: POST /onboarding with public certificate of the device (could exchange additional info)
     WFMUser->>Server: Opportunity for user to approve or reject client onboarding
     alt Public key trusted/user approved
         Note over Server: Server verifies client certificate and assigns UUID


### PR DESCRIPTION
### Description

Fixes an incorrect field name i.e. `public_certificate` in device onboarding sequence diagram in the doc file.

#### Issues Addressed

Closes #133 

#### Change Type

Please select the relevant options:

- [ ] Fix (change that resolves an issue)
- [ ] New enhancement (change that adds specification content)
- [x] Content edits (change that edits existing content)

#### Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [x] My changes adhere to the established patterns, and best practices.
