### PR TITLE
Fix/packagefile location for compose applications

### DIFF
--- a/src/specification/applications/application-description.linkml.yaml
+++ b/src/specification/applications/application-description.linkml.yaml
@@ -403,7 +403,7 @@ classes:
         rank: 40
         range: string
       packageLocation:
-        description: URL indicating the Compose package's location. The URL indicating the Compose package's location. It should be direct path to compose.yaml or compose.yaml file archived in tar.gz
+        description: The URL indicating the Compose package's location. It should be direct path to compose.yaml or compose.yaml file archived in tar.gz
         rank: 50
         range: string
       keyLocation:

--- a/src/specification/applications/application-description.linkml.yaml
+++ b/src/specification/applications/application-description.linkml.yaml
@@ -403,7 +403,7 @@ classes:
         rank: 40
         range: string
       packageLocation:
-        description: The URL indicating the Compose package's location. It should be direct path to compose.yaml or compose.yaml file archived in tar.gz
+        description: The URL indicating the Compose package's location. It should be a direct path to the compose.yaml or compose.yaml file archived in tar.gz
         rank: 50
         range: string
       keyLocation:

--- a/src/specification/applications/application-description.linkml.yaml
+++ b/src/specification/applications/application-description.linkml.yaml
@@ -403,7 +403,7 @@ classes:
         rank: 40
         range: string
       packageLocation:
-        description: URL indicating the Compose package's location.
+        description: URL indicating the Compose package's location. The URL indicating the Compose package's location. It should be direct path to compose.yaml or compose.yaml file archived in tar.gz
         rank: 50
         range: string
       keyLocation:

--- a/src/specification/applications/resources/index.md.jinja2
+++ b/src/specification/applications/resources/index.md.jinja2
@@ -89,7 +89,7 @@ The expected properties for the suppported deployment types are indicated below.
 
 | Attribute      | Type  | Required?     | Description    |
 | --- | --- | --- | --- |
-| packageLocation  | string |  Y  | The URL indicating the Compose package's location. |
+| packageLocation  | string |  Y  | The URL indicating the Compose package's location. It should be direct path to compose.yaml or compose file archived in tar.gz |
 | keyLocation    | string | N  | The public key used to validated the digitally signed package. It is highly recommend to digitally sign the package. When signing the package PGP MUST be used.|
 | wait | bool  | N  | If `True`, indicates the device MUST wait until the Compose file has finished starting up before starting the next Compose file. The default is `True`. The Workload Fleet Management Client MUST support `True` and MAY support `False`. Only applies if multiple `compose` components are provided.|
 | timeout | string      | N   | The time to wait for the component's installation to complete. If the installation does not completed before the timeout occurs the installation process fails. The format is "##m##s" indicating the total number of minutes and seconds to wait.|

--- a/src/specification/applications/resources/index.md.jinja2
+++ b/src/specification/applications/resources/index.md.jinja2
@@ -89,7 +89,7 @@ The expected properties for the suppported deployment types are indicated below.
 
 | Attribute      | Type  | Required?     | Description    |
 | --- | --- | --- | --- |
-| packageLocation  | string |  Y  | The URL indicating the Compose package's location. It should be direct path to compose.yaml or compose file archived in tar.gz |
+| packageLocation  | string |  Y  | The URL indicating the Compose package's location. It should be a direct path to the compose.yaml or compose file archived in tar.gz |
 | keyLocation    | string | N  | The public key used to validated the digitally signed package. It is highly recommend to digitally sign the package. When signing the package PGP MUST be used.|
 | wait | bool  | N  | If `True`, indicates the device MUST wait until the Compose file has finished starting up before starting the next Compose file. The default is `True`. The Workload Fleet Management Client MUST support `True` and MAY support `False`. Only applies if multiple `compose` components are provided.|
 | timeout | string      | N   | The time to wait for the component's installation to complete. If the installation does not completed before the timeout occurs the installation process fails. The format is "##m##s" indicating the total number of minutes and seconds to wait.|

--- a/system-design/specification/margo-management-interface/workload-management-api-1.0.0.yaml
+++ b/system-design/specification/margo-management-interface/workload-management-api-1.0.0.yaml
@@ -626,7 +626,7 @@ components:
           properties:
             packageLocation:
               type: string
-              description: The URL indicating the Compose package's location. It should be direct path to compose.yaml or compose.yaml file archived in tar.gz
+              description: The URL indicating the Compose package's location. It should be a direct path to the compose.yaml or compose.yaml file archived in tar.gz
             keyLocation:
               type: string
               description: Key location of the component

--- a/system-design/specification/margo-management-interface/workload-management-api-1.0.0.yaml
+++ b/system-design/specification/margo-management-interface/workload-management-api-1.0.0.yaml
@@ -626,7 +626,7 @@ components:
           properties:
             packageLocation:
               type: string
-              description: Package location of the component
+              description: The URL indicating the Compose package's location. It should be direct path to compose.yaml or compose.yaml file archived in tar.gz
             keyLocation:
               type: string
               description: Key location of the component


### PR DESCRIPTION
### Description

Compose app packageLocation information on margo docs is not clear. There is possibilities of users providing packageLocation as any kind of archive URL.

#### Issues Addressed

This PR allows user to provide packagelocation either as compose.yaml file within tar.gz or direct URL path to compose.yaml

#### Change Type

Please select the relevant options:


- [ ] New enhancement (change that adds specification content)


#### Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [ ] My changes adhere to the established patterns, and best practices.
