### PR TITLE
docs: clarify overridable parameter naming in example manifests

### DIFF
--- a/src/specification/applications/resources/examples/valid/ApplicationDescription-001.yaml
+++ b/src/specification/applications/resources/examples/valid/ApplicationDescription-001.yaml
@@ -33,6 +33,8 @@ parameters:
   greeting:
     value: Hello
     targets:
+    # Maps to deployment configuration param,
+    # e.g., helm install ... --set global.config.appGreeting="Hello"
     - pointer: global.config.appGreeting
       components: ["hello-world"]
   greetingAddressee:

--- a/src/specification/applications/resources/examples/valid/ApplicationDescription-002.yaml
+++ b/src/specification/applications/resources/examples/valid/ApplicationDescription-002.yaml
@@ -63,19 +63,19 @@ parameters:
     targets:
       - pointer: idp.name
         components: ["digitron-orchestrator"]
-      - pointer: ENV.IDP_NAME
+      - pointer: IDP_NAME
         components: ["digitron-orchestrator-docker"]
   idpProvider:
     targets:
       - pointer: idp.provider
         components: ["digitron-orchestrator"]
-      - pointer: ENV.IDP_PROVIDER
+      - pointer: IDP_PROVIDER
         components: ["digitron-orchestrator-docker"]
   idpClientId:
     targets:
       - pointer: idp.clientId
         components: ["digitron-orchestrator"]
-      - pointer: ENV.IDP_CLIENT_ID
+      - pointer: IDP_CLIENT_ID
         components: ["digitron-orchestrator-docker"]
   idpUrl:
     targets:
@@ -83,32 +83,32 @@ parameters:
         components: ["digitron-orchestrator"]
       - pointer: idp.providerMetadata
         components: ["digitron-orchestrator"]
-      - pointer: ENV.IDP_URL
+      - pointer: IDP_URL
         components: ["digitron-orchestrator-docker"]
   adminName:
     targets:
       - pointer: administrator.name
         components: ["digitron-orchestrator"]
-      - pointer: ENV.ADMIN_NAME
+      - pointer: ADMIN_NAME
         components: ["digitron-orchestrator-docker"]
   adminPrincipalName:
     targets:
       - pointer: administrator.userPrincipalName
         components: ["digitron-orchestrator"]
-      - pointer: ENV.ADMIN_PRINCIPALNAME
+      - pointer: ADMIN_PRINCIPALNAME
         components: ["digitron-orchestrator-docker"]
   pollFrequency:
     value: 30
     targets: 
       - pointer: settings.pollFrequency
         components: ["digitron-orchestrator", "database-services"]
-      - pointer: ENV.POLL_FREQUENCY
+      - pointer: POLL_FREQUENCY
         components: ["digitron-orchestrator-docker"]
   siteId:
     targets:
       - pointer: settings.siteId
         components: ["digitron-orchestrator", "database-services"]
-      - pointer: ENV.SITE_ID
+      - pointer: SITE_ID
         components: ["digitron-orchestrator-docker"]
   cpuLimit:
     value: 1 

--- a/src/specification/applications/resources/examples/valid/ApplicationDescription-002.yaml
+++ b/src/specification/applications/resources/examples/valid/ApplicationDescription-002.yaml
@@ -60,9 +60,13 @@ deploymentProfiles:
           keyLocation: https://northsitarida.com/digitron/docker/public-key.asc
 parameters:
   idpName:
+    value: "test"
     targets:
+      # Maps to deployment configuration param,
+      # e.g., helm install ... --set idp.name="test"
       - pointer: idp.name
         components: ["digitron-orchestrator"]
+      # Maps to environment variables, e.g., IDP_NAME=test docker compose ...
       - pointer: IDP_NAME
         components: ["digitron-orchestrator-docker"]
   idpProvider:

--- a/src/specification/margo-management-interface/resources/examples/valid/DesiredState-002.yaml
+++ b/src/specification/margo-management-interface/resources/examples/valid/DesiredState-002.yaml
@@ -18,48 +18,48 @@ spec:
         adminName:
             value: Some One
             targets:
-                - pointer: ENV.ADMIN_NAME
+                - pointer: ADMIN_NAME
                   components:
                     - digitron-orchestrator-docker
         adminPrincipalName:
             value: someone@somewhere.com
             targets:
-                - pointer: ENV.ADMIN_PRINCIPALNAME
+                - pointer: ADMIN_PRINCIPALNAME
                   components:
                     - digitron-orchestrator-docker
         idpClientId:
             value: 123-ABC
             targets:
-                - pointer: ENV.IDP_CLIENT_ID
+                - pointer: IDP_CLIENT_ID
                   components:
                     - digitron-orchestrator-docker
         idpName:
             value: Azure AD
             targets:
-                - pointer: ENV.IDP_NAME
+                - pointer: IDP_NAME
                   components:
                     - digitron-orchestrator-docker
         idpProvider:
             value: aad
             targets:
-                - pointer: ENV.IDP_PROVIDER
+                - pointer: IDP_PROVIDER
                   components:
                     - digitron-orchestrator-docker
         idpUrl:
             value: https://123-abc.com
             targets:
-                - pointer: ENV.IDP_URL
+                - pointer: IDP_URL
                   components:
                     - digitron-orchestrator-docker
         pollFrequency:
             value: "120"
             targets:
-                - pointer: ENV.POLL_FREQUENCY
+                - pointer: POLL_FREQUENCY
                   components:
                     - digitron-orchestrator-docker
         siteId:
             value: SID-123-ABC
             targets:
-                - pointer: ENV.SITE_ID
+                - pointer: SITE_ID
                   components:
                     - digitron-orchestrator-docker


### PR DESCRIPTION
### Description

Remove the misleading "ENV." prefix from example pointer values to
clarify that target names are vendor-defined and opaque to the device.
Also adds comments in the example manifests to clarify,
what the pointer attributes actually are.

#### Issues Addressed

Closes #167 

#### Change Type

Please select the relevant options:

- [ ] Fix (change that resolves an issue)
- [ ] New enhancement (change that adds specification content)
- [x] Content edits (change that edits existing content)

#### Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [x] My changes adhere to the established patterns, and best practices.
