### PR TITLE
docs(md): clarifies the isolation of margo sliced resources on device

### DIFF
--- a/system-design/specification/margo-management-interface/device-capabilities.md
+++ b/system-design/specification/margo-management-interface/device-capabilities.md
@@ -2,6 +2,8 @@
 
 Devices MUST provide the Workload Fleet Management service with its capabilities and characteristics. This is done by calling the Device API's `device capabilities` endpoint. Reporting the device capabilities is the final step in the onboarding of the device's client. 
 
+The reported capabilities represent only the subset of device resources delegated exclusively to Margo for workload placement and reconciliation, and do not necessarily reflect the device's total physical capacity. The mechanisms used to isolate, reserve, and preserve these resources for exclusive Margo use are implementation-specific and outside the scope of this specification.
+
 To ensure the WFM is kept up to date, the device's client MUST send updated capabilities information if any changes occur to the information originally provided (i.e., additional memory is added to the device).
 
 - Requests to this endpoint MUST be authenticated using the HTTP Message Signature method as defined in the [Payload Security](../margo-management-interface/api-requirements-and-security.md#payload-security-method) section.


### PR DESCRIPTION
### Description

Device capabilities documentation doesn't clarify that the resources are sliced and guaranteed on device solely for Margo usage and cannot be shared by other system entities.

#### Issues Addressed

#159 

#### Change Type

Please select the relevant options:

- [ ] Fix (change that resolves an issue)
- [ ] New enhancement (change that adds specification content)
- [x] Content edits (change that edits existing content)

#### Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [x] My changes adhere to the established patterns, and best practices.
