### PR TITLE
docs: fixes rendering of parameter table in docs for app desc and deployment

### DIFF
--- a/src/specification/applications/application-description.linkml.yaml
+++ b/src/specification/applications/application-description.linkml.yaml
@@ -417,7 +417,7 @@ classes:
     description: >-
       Defines a configurable parameter for the application.
       This object is used to build a property bag, i.e. `parameters`, defined in application description.
-      See `parameters` attribute under [ApplicationDescription Attributes](application-description.md#top-level-attributes) section for better understanding.
+      See `parameters` attribute under [ApplicationDescription Attributes](#top-level-attributes) section for better understanding.
     rank: 90
     attributes:
       name: 

--- a/src/specification/applications/application-description.linkml.yaml
+++ b/src/specification/applications/application-description.linkml.yaml
@@ -51,7 +51,7 @@ classes:
       parameters:
         description: >-
           Parameters element specifying the configurable parameters to use when installing, or updating, the application.
-          Defined as a map where each key is the user-defined parameter name (e.g., e.g., `mysqlDatabase:`, `greeting:`, `idpName:`, `myAppEndpoint:`),
+          Defined as a map where each key is the user-defined parameter name (e.g. `mysqlDatabase:`, `greeting:`, `idpName:`, `myAppEndpoint:`),
           and value would be Parameter object, i.e. map[string]Parameter
           See the [Parameter](#parameter-attributes) section below.
         range: Parameter 

--- a/src/specification/applications/application-description.linkml.yaml
+++ b/src/specification/applications/application-description.linkml.yaml
@@ -51,6 +51,8 @@ classes:
       parameters:
         description: >-
           Parameters element specifying the configurable parameters to use when installing, or updating, the application.
+          Defined as a map where each key is the user-defined parameter name (e.g., e.g., `mysqlDatabase:`, `greeting:`, `idpName:`, `myAppEndpoint:`),
+          and value would be Parameter object, i.e. map[string]Parameter
           See the [Parameter](#parameter-attributes) section below.
         range: Parameter 
         multivalued: true

--- a/src/specification/applications/application-description.linkml.yaml
+++ b/src/specification/applications/application-description.linkml.yaml
@@ -52,7 +52,7 @@ classes:
         description: >-
           Parameters element specifying the configurable parameters to use when installing, or updating, the application.
           Defined as a map where each key is the user-defined parameter name (e.g. `mysqlDatabase:`, `greeting:`, `idpName:`, `myAppEndpoint:`),
-          and value would be Parameter object, i.e. map[string]Parameter
+          and value would be Parameter object, i.e. map[string]Parameter.
           See the [Parameter](#parameter-attributes) section below.
         range: Parameter 
         multivalued: true
@@ -414,7 +414,10 @@ classes:
         range: string
 
   Parameter:
-    description: Defines a configurable parameter for the application.
+    description: >-
+      Defines a configurable parameter for the application.
+      This object is used to build a property bag, i.e. `parameters`, defined in application description.
+      See `parameters` attribute under [ApplicationDescription Attributes](application-description.md#top-level-attributes) section for better understanding.
     rank: 90
     attributes:
       name: 

--- a/src/specification/applications/resources/index.md.jinja2
+++ b/src/specification/applications/resources/index.md.jinja2
@@ -69,6 +69,7 @@ which defines the [desired state](../margo-management-interface/desired-state.md
 
 
 {%- if c.name.startswith("DeploymentProfile") %}
+
 #### Helm Exceptions
 
 Applications can be deployed as Helm charts using either Helm [version 3](https://helm.sh/docs/v3/topics/charts) or [version 4](https://helm.sh/docs/topics/charts) using Chart APIVersion v2 only.

--- a/src/specification/applications/resources/index.md.jinja2
+++ b/src/specification/applications/resources/index.md.jinja2
@@ -56,13 +56,14 @@ which defines the [desired state](../margo-management-interface/desired-state.md
 
 | Attribute | Type | Required? | Description |
 | --- | --- | --- | --- |
-{% for slot in gen.get_direct_slots(c)|sort(attribute='rank') -%}
-{%- if slot.name != "value" -%}
+{%- for slot in gen.get_direct_slots(c)|sort(attribute='rank') %}
+{%- if c.name == "Parameter" and slot.name == "name" %}
+{%- elif slot.name != "value" %}
 | {{ slot.name }} | {{ format_range(slot) }} | {% if slot.required == True %} Y {% else %} N {% endif %} | {{ slot.description }}|
-{%- else -%}
+{%- else %}
 | {{ slot.name }} | <*see description*> | {% if slot.required == True %} Y {% else %} N {% endif %} | {{ slot.description }}|
 {%- endif %}
-{% endfor %}
+{%- endfor %}
 
 {%- endif %}
 

--- a/src/specification/margo-management-interface/desired-state.linkml.yaml
+++ b/src/specification/margo-management-interface/desired-state.linkml.yaml
@@ -100,7 +100,10 @@ classes:
         required: true
         rank: 10
       parameters:
-        description: Describes the configured parameters applied via the end-user.
+        description: >-
+          Describes the configured parameters applied via the end-user.
+          Defined as a map where each key is the parameter name matching a parameter defined in the ApplicationDescription
+          (e.g., `mysqlDatabase:`, `greeting:`, `idpName:`, `myAppEndpoint:`); unrecognized keys are ignored.
         range: Parameter
         required: true
         multivalued: true

--- a/src/specification/margo-management-interface/resources/index.md.jinja2
+++ b/src/specification/margo-management-interface/resources/index.md.jinja2
@@ -324,9 +324,13 @@ spec:
 
 | Attribute | Type | Required? | Description |
 | --- | --- | --- | --- |
-{% for slot in gen.get_direct_slots(c)|sort(attribute='rank') -%}
+{%- for slot in gen.get_direct_slots(c)|sort(attribute='rank') -%}
+{%- set parameters_slot = schemaview.get_slot("parameters") -%}
+{%- set is_map_key = parameters_slot and parameters_slot.range == c.name and not parameters_slot.inlined_as_list and slot.identifier %}
+{%- if not is_map_key %}
 | {{ slot.name }} | {{ format_range(slot) }} | {% if slot.required == True %} Y {% else %} N {% endif %} | {{ slot.description }}|
-{% endfor %}
+{%- endif %}
+{%- endfor %}
 {%- endif %}
 {%- endfor %}
 


### PR DESCRIPTION
### Description

The docs rendered for application-description and application-deployment show `name` object to be an explicit field in `parameters` object (a `key:value` map), whereas it refers to the `key` attribute of the map.

#### Issues Addressed

Closes #169

#### Change Type

Please select the relevant options:

- [x] Fix (change that resolves an issue)
- [ ] New enhancement (change that adds specification content)
- [ ] Content edits (change that edits existing content)

#### Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [x] My changes adhere to the established patterns, and best practices.
