### PR TITLE
adding pr age check to workflow

### DIFF
--- a/.github/workflows/pr-age-check.yaml
+++ b/.github/workflows/pr-age-check.yaml
@@ -1,0 +1,23 @@
+name: PR Age Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+
+jobs:
+  check-pr-age:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR Age
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prCreatedAt = new Date(context.payload.pull_request.created_at);
+            const now = new Date();
+            const ageInDays = (now - prCreatedAt) / (1000 * 60 * 60 * 24);
+
+            if (ageInDays < 7) {
+              core.setFailed(`PR must be open for at least 7 days. Currently: ${ageInDays.toFixed(2)} days.`);
+            } else {
+              console.log(`PR is old enough: ${ageInDays.toFixed(2)} days.`);
+            }

--- a/.github/workflows/pr-age-check.yaml
+++ b/.github/workflows/pr-age-check.yaml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, ready_for_review]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   check-pr-age:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description

Adding a workflow to ensure PRs cannot be closed (normally) until after the required 1-week minimum period is over.

#### Issues Addressed

List and link all the issues addressed by this PR.

#### Change Type

Please select the relevant options:

- [ ] Fix (change that resolves an issue)
- [ ] New enhancement (change that adds specification content)
- [ ] Content edits (change that edits existing content)

#### Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [ ] My changes adhere to the established patterns, and best practices.
